### PR TITLE
Align with latest libfap

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ python-libfap
 
 Python ctypes bindings for libfap, the C port of the HAM::APRS::FAP Finnish APRS Parser
 
-See <http://pakettiradio.net/libfap/> for more information and documentation on the libfap APRS parser.
+libfap version 1.5 must be installed. See <http://pakettiradio.net/libfap/> for more information and documentation on the libfap APRS parser.
 
 See `example.py` for example usage.
 
@@ -19,6 +19,10 @@ Before running `example.py`, you will need to configure your APRS login informat
 
 Compatibility
 -------------
+
+Compatible with libfap 1.5.
+
+Operating Systems:
 
 * Linux
 * Mac OS X

--- a/example.py
+++ b/example.py
@@ -16,9 +16,9 @@ sock_file = sock.makefile()
 libfap.fap_init()
 try:
     while 1:
-        packet_str = sock_file.readline().strip()
+        packet_str = sock_file.readline()
         packet = libfap.fap_parseaprs(packet_str, len(packet_str), 0)
-        print '%s' % (packet[0])
+        print '%s %s' % (packet[0].src_callsign, packet[0].body)
         libfap.fap_free(packet)
 except KeyboardInterrupt:
     pass

--- a/libfap.py
+++ b/libfap.py
@@ -82,6 +82,7 @@ fap_error_code_t = c_int
     fapMICE_AMB_ODD,
     
     fapCOMP_INV,
+    fapCOMP_SHORT,
     
     fapMSG_INV,
     
@@ -103,7 +104,7 @@ fap_error_code_t = c_int
     fapNMEA_NOFIELDS,
     
     fapNO_APRS
-) = map(c_int, xrange(62))
+) = map(c_int, xrange(63))
 
 # fap_packet_type_t
 (
@@ -157,12 +158,12 @@ class fap_wx_report_t(Structure):
 
 class fap_telemetry_t(Structure):
     _fields_ = [
-        ('seq', c_uint),
-        ('val1', c_double),
-        ('val2', c_double),
-        ('val3', c_double),
-        ('val4', c_double),
-        ('val5', c_double),
+        ('seq', POINTER(c_uint)),
+        ('val1', POINTER(c_double)),
+        ('val2', POINTER(c_double)),
+        ('val3', POINTER(c_double)),
+        ('val4', POINTER(c_double)),
+        ('val5', POINTER(c_double)),
         
         ('bits', c_byte * 8),
     ]
@@ -170,7 +171,6 @@ class fap_telemetry_t(Structure):
 class fap_packet_t(Structure):
     _fields_ = [
         ('error_code', POINTER(fap_error_code_t)), # POINTER(fap_error_code_t)
-        ('error_message', c_char_p),
         ('type', POINTER(c_int)), # POINTER(fap_packet_type_t)
         
         ('orig_packet', c_char_p),
@@ -215,6 +215,7 @@ class fap_packet_t(Structure):
         ('radio_range', POINTER(c_uint)),
         ('phg', c_char_p),
         ('timestamp', POINTER(time_t)),
+        ('raw_timestamp', c_char_p),
         ('nmea_checksum_ok', POINTER(c_short)),
         
         ('wx_report', POINTER(fap_wx_report_t)),
@@ -227,20 +228,20 @@ class fap_packet_t(Structure):
         ('capabilities', POINTER(c_char_p)),
         ('capabilities_len', c_uint),
     ]
-    
+
     def get_timestamp(self):
-        return datetime.fromtimestamp(self.timestamp[0])
+        return datetime.fromtimestamp(self.timestamp.contents)
     
     def __repr__(self):
         return '%s(\'%s:%s\')' % (self.__class__.__name__, self.header, self.body)
 
 libfap.fap_parseaprs.restype = POINTER(fap_packet_t)
 
-libfap.fap_explain_error.argtypes = [fap_error_code_t]
-libfap.fap_explain_error.restype = c_char_p
+libfap.fap_explain_error.argtypes = [fap_error_code_t, c_char_p]
+libfap.fap_explain_error.restype = None
 
-libfap.fap_mice_mbits_to_message.argtypes = [c_char_p]
-libfap.fap_mice_mbits_to_message.restype = c_char_p
+libfap.fap_mice_mbits_to_message.argtypes = [c_char_p, c_char_p]
+libfap.fap_mice_mbits_to_message.restype = None
 
 libfap.fap_distance.argtypes = [c_double, c_double, c_double, c_double]
 libfap.fap_distance.restype = c_double

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+setup(name='python-libfap',
+        version='0.1',
+        description='Python ctypes bindings for libfap, the C port of the HAM::APRS::FAP Finnish APRS Parser',
+        author='Tom Hayward',
+        author_email='tom@tomh.us',
+        url='https://github.com/kd7lxl/python-libfap',
+        py_modules=['libfap'],
+        )
+


### PR DESCRIPTION
To align with latest libfap (as of 2015/02/13, see https://github.com/Turbo87/libfap/blob/master/src/fap.h ) , class fap_packet_t(Structure):
    _fields_ 

 should be modified as follows:
1) ('raw_timestamp', c_char_p)  needs to be inserted after:         ('timestamp', POINTER(time_t)),
2) ('error_message', c_char_p) needs to be deleted. 
Without these changes a segfault is raised
